### PR TITLE
pyrestcli 0.6.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.7.0
-pyrestcli==0.6.11
+pyrestcli==0.6.12


### PR DESCRIPTION
backwards-compatible with 0.6.11